### PR TITLE
feat: Add GitHubFetcher and unit tests

### DIFF
--- a/src/github_api/fetcher.py
+++ b/src/github_api/fetcher.py
@@ -1,0 +1,136 @@
+"""
+GitHub APIクライアント (client.py) を使用して、PR、Issueコメント、レビューコメントといった
+特定の種類のデータを取得する高レベルなロジックを実装します。
+最後に取得した日時を考慮したフィルタリングを行います。
+"""
+import logging
+from typing import Dict, List, Optional, Tuple, Any
+from src.github_api.client import GitHubAPIClient
+# Import DatabaseHandler once it's defined and needed
+# from src.db.database import DatabaseHandler # Assuming DatabaseHandler is in database.py
+
+logger = logging.getLogger(__name__)
+
+class GitHubFetcher:
+    """
+    GitHub APIクライアントを使用して、特定の種類のデータを取得する高レベルなロジックを実装します。
+    """
+
+    def __init__(self, client: GitHubAPIClient): # db_handler: DatabaseHandler):
+        """
+        GitHubFetcherを初期化します。
+
+        Args:
+            client: GitHubAPIClientのインスタンス。
+            db_handler: DatabaseHandlerのインスタンス。
+        """
+        self.client = client
+        # self.db_handler = db_handler # Will be used later
+
+    def get_last_fetched_at(self, repo_full_name: str) -> Optional[str]:
+        """
+        指定されたリポジトリの最終取得日時をデータベースから取得します。
+        現時点ではデータベースハンドラが完全に統合されていないため、Noneを返します。
+        実際の処理では、self.db_handlerを使用してデータベースにクエリを実行します。
+
+        Args:
+            repo_full_name: "owner/repo"形式のリポジトリ名。
+
+        Returns:
+            最終取得日時のISO 8601形式の文字列。見つからない場合はNone。
+        """
+        # Placeholder: In a real scenario, this would query the database
+        # e.g., return self.db_handler.get_last_fetched_timestamp(repo_full_name)
+        logger.info(f"'{repo_full_name}' の最終取得日時を問い合わせ (現在はNoneを返却)")
+        return None
+
+    def fetch_all_data_for_repo(
+        self,
+        repo_full_name: str
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """
+        指定されたリポジトリのプルリクエスト、Issueコメント、レビューコメントをすべて取得します。
+
+        Args:
+            repo_full_name: "owner/repo"形式のリポジトリ名。
+
+        Returns:
+            プルリクエストのリスト、Issueコメントのリスト、レビューコメントのリストのタプル。
+        """
+        owner, repo = repo_full_name.split('/')
+        since = self.get_last_fetched_at(repo_full_name)
+
+        logger.info(f"'{repo_full_name}' のデータ取得開始 (since: {since})")
+
+        pull_requests = self.client.get_pull_requests(owner, repo, since=since)
+        logger.info(f"'{repo_full_name}' からPR {len(pull_requests)}件を取得")
+
+        all_issue_comments: List[Dict[str, Any]] = []
+        all_review_comments: List[Dict[str, Any]] = []
+
+        for pr in pull_requests:
+            pr_number = pr.get("number")
+            if not pr_number:
+                logger.warning(f"PRデータに 'number' が含まれていません: {pr.get('id')}")
+                continue
+
+            # Issueコメントの取得 (PRはIssueでもあるため)
+            # Note: The design doc mentions /repos/{owner}/{repo}/issues/{issue_number}/comments
+            # and /repos/{owner}/{repo}/pulls/{pull_number}/comments.
+            # For simplicity here, we'll use PR number for both, assuming PRs are a subset of issues.
+            # A more robust solution might differentiate or fetch all issues separately.
+            issue_comments = self.client.get_issue_comments(owner, repo, issue_number=pr_number, since=since)
+            logger.debug(f"PR #{pr_number} ({repo_full_name}) からIssueコメント {len(issue_comments)}件を取得")
+            all_issue_comments.extend(issue_comments)
+
+            # レビューコメントの取得
+            review_comments = self.client.get_review_comments(owner, repo, pull_number=pr_number, since=since)
+            logger.debug(f"PR #{pr_number} ({repo_full_name}) からレビューコメント {len(review_comments)}件を取得")
+            all_review_comments.extend(review_comments)
+
+        logger.info(f"'{repo_full_name}' のデータ取得完了。PRs: {len(pull_requests)}, Issueコメント: {len(all_issue_comments)}, レビューコメント: {len(all_review_comments)}")
+        return pull_requests, all_issue_comments, all_review_comments
+
+if __name__ == "__main__":
+    # このブロックは基本的なテストや手動実行用です。
+    # ユニットテストは別途 test_fetcher.py に記述します。
+    from src.config.settings import Settings
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    logger.info("GitHub Fetcher の手動テスト実行開始")
+
+    try:
+        settings = Settings() # 環境変数などから設定を読み込む
+        api_client = GitHubAPIClient(settings)
+        fetcher = GitHubFetcher(api_client) #, db_handler_mock) # db_handlerはモックまたは実際のインスタンス
+
+        # settings.repositories は設定ファイルや環境変数から読み込まれる想定
+        if settings.repositories:
+            test_repo_full_name = settings.repositories[0] # 最初の設定済みリポジトリを使用
+            logger.info(f"テスト対象リポジトリ: {test_repo_full_name}")
+
+            prs, issue_comments, review_comments = fetcher.fetch_all_data_for_repo(test_repo_full_name)
+
+            print(f"\n--- Fetched Data for {test_repo_full_name} ---")
+            print(f"Pull Requests: {len(prs)}")
+            # for pr in prs:
+            # print(f"  - PR #{pr.get('number')}: {pr.get('title')}")
+
+            print(f"Issue Comments: {len(issue_comments)}")
+            # for comment in issue_comments:
+            # print(f"  - Comment ID {comment.get('id')} on PR ??: {comment.get('body', '')[:50]}...")
+
+            print(f"Review Comments: {len(review_comments)}")
+            # for comment in review_comments:
+            # print(f"  - Comment ID {comment.get('id')} on PR #{comment.get('pull_request_url', '').split('/')[-1]}: {comment.get('body', '')[:50]}...")
+
+        else:
+            logger.warning("設定ファイルにリポジトリが指定されていません。手動テストはスキップされます。")
+
+    except Exception as e:
+        logger.error(f"手動テスト中にエラーが発生: {e}", exc_info=True)
+
+    logger.info("GitHub Fetcher の手動テスト実行終了")

--- a/tests/unit/github_api/test_fetcher.py
+++ b/tests/unit/github_api/test_fetcher.py
@@ -1,0 +1,281 @@
+"""
+Unit tests for src/github_api/fetcher.py
+"""
+import pytest
+from unittest.mock import MagicMock, call, patch
+from typing import List, Dict, Any, Optional, Tuple
+
+# Modules to test
+from src.github_api.fetcher import GitHubFetcher
+from src.github_api.client import GitHubAPIClient
+# Mocked version of DatabaseHandler, actual import not needed for these tests
+# from src.db.database import DatabaseHandler
+
+# Mock data
+mock_pr_data_page1 = [
+    {"id": 1, "number": 101, "title": "Feature: New login page"},
+    {"id": 2, "number": 102, "title": "Bugfix: User logout issue"},
+]
+mock_pr_data_page2 = [
+    {"id": 3, "number": 103, "title": "Docs: Update README"},
+]
+
+mock_issue_comments_pr101 = [
+    {"id": 10, "body": "Comment on PR 101"},
+]
+mock_issue_comments_pr102 = [
+    {"id": 11, "body": "Another comment on PR 102"},
+]
+mock_issue_comments_pr103 = [] # No issue comments for PR 103
+
+mock_review_comments_pr101 = [] # No review comments for PR 101
+mock_review_comments_pr102 = [
+    {"id": 20, "body": "Review comment on PR 102, file main.py", "path": "main.py"},
+]
+mock_review_comments_pr103 = [
+    {"id": 21, "body": "Review comment on PR 103, file README.md", "path": "README.md"},
+    {"id": 22, "body": "Second review comment on PR 103", "path": "README.md"},
+]
+
+
+@pytest.fixture
+def mock_api_client() -> MagicMock:
+    """Fixture for a mocked GitHubAPIClient."""
+    client = MagicMock(spec=GitHubAPIClient)
+
+    # Default behavior for get_pull_requests
+    client.get_pull_requests.return_value = mock_pr_data_page1 + mock_pr_data_page2
+
+    # Default behavior for get_issue_comments and get_review_comments
+    # These will be configured per test as needed, or use side_effect
+    def get_issue_comments_side_effect(owner: str, repo: str, issue_number: int, since: Optional[str] = None):
+        if issue_number == 101: return mock_issue_comments_pr101
+        if issue_number == 102: return mock_issue_comments_pr102
+        if issue_number == 103: return mock_issue_comments_pr103
+        return []
+    client.get_issue_comments.side_effect = get_issue_comments_side_effect
+
+    def get_review_comments_side_effect(owner: str, repo: str, pull_number: int, since: Optional[str] = None):
+        if pull_number == 101: return mock_review_comments_pr101
+        if pull_number == 102: return mock_review_comments_pr102
+        if pull_number == 103: return mock_review_comments_pr103
+        return []
+    client.get_review_comments.side_effect = get_review_comments_side_effect
+
+    return client
+
+@pytest.fixture
+def mock_db_handler() -> MagicMock:
+    """Fixture for a mocked DatabaseHandler."""
+    # db_handler = MagicMock(spec=DatabaseHandler)
+    # For now, GitHubFetcher doesn't use db_handler in its constructor.
+    # When it does, this mock will be more relevant.
+    # For get_last_fetched_at, we will mock the method on the fetcher instance directly.
+    return MagicMock()
+
+
+def test_github_fetcher_initialization(mock_api_client: MagicMock):
+    """Test GitHubFetcher initialization."""
+    fetcher = GitHubFetcher(client=mock_api_client) #, db_handler=mock_db_handler)
+    assert fetcher.client == mock_api_client
+    # assert fetcher.db_handler == mock_db_handler # Enable when db_handler is used in constructor
+
+def test_get_last_fetched_at_no_timestamp(mock_api_client: MagicMock, mock_db_handler: MagicMock):
+    """Test get_last_fetched_at when no timestamp is in the (mocked) DB."""
+    fetcher = GitHubFetcher(client=mock_api_client) #, db_handler=mock_db_handler)
+
+    # Mock the behavior of the db_handler if it were used directly
+    # For now, we assume get_last_fetched_at is simple or we patch it if it uses db_handler
+    # fetcher.db_handler.get_last_fetched_timestamp.return_value = None
+    # Since get_last_fetched_at is currently a placeholder:
+    with patch.object(fetcher, 'get_last_fetched_at', return_value=None) as mock_method:
+        timestamp = fetcher.get_last_fetched_at("owner/repo")
+        assert timestamp is None
+        mock_method.assert_called_once_with("owner/repo")
+
+def test_get_last_fetched_at_with_timestamp(mock_api_client: MagicMock, mock_db_handler: MagicMock):
+    """Test get_last_fetched_at when a timestamp is in the (mocked) DB."""
+    fetcher = GitHubFetcher(client=mock_api_client) #, db_handler=mock_db_handler)
+    expected_timestamp = "2023-01-01T00:00:00Z"
+
+    # fetcher.db_handler.get_last_fetched_timestamp.return_value = expected_timestamp
+    # Since get_last_fetched_at is currently a placeholder:
+    with patch.object(fetcher, 'get_last_fetched_at', return_value=expected_timestamp) as mock_method:
+        timestamp = fetcher.get_last_fetched_at("owner/repo")
+        assert timestamp == expected_timestamp
+        mock_method.assert_called_once_with("owner/repo")
+
+
+def test_fetch_all_data_for_repo_initial_fetch(mock_api_client: MagicMock):
+    """Test fetch_all_data_for_repo for an initial fetch (no 'since' parameter)."""
+    repo_full_name = "test_owner/test_repo"
+    fetcher = GitHubFetcher(client=mock_api_client)
+
+    # Ensure get_last_fetched_at returns None for this test
+    fetcher.get_last_fetched_at = MagicMock(return_value=None)
+
+    prs, issue_comments, review_comments = fetcher.fetch_all_data_for_repo(repo_full_name)
+
+    # Verify get_last_fetched_at was called
+    fetcher.get_last_fetched_at.assert_called_once_with(repo_full_name)
+
+    # Verify client methods were called correctly
+    owner, repo = repo_full_name.split('/')
+    mock_api_client.get_pull_requests.assert_called_once_with(owner, repo, since=None)
+
+    expected_issue_comment_calls = [
+        call(owner, repo, issue_number=101, since=None),
+        call(owner, repo, issue_number=102, since=None),
+        call(owner, repo, issue_number=103, since=None),
+    ]
+    mock_api_client.get_issue_comments.assert_has_calls(expected_issue_comment_calls, any_order=True)
+    assert mock_api_client.get_issue_comments.call_count == len(mock_pr_data_page1) + len(mock_pr_data_page2)
+
+
+    expected_review_comment_calls = [
+        call(owner, repo, pull_number=101, since=None),
+        call(owner, repo, pull_number=102, since=None),
+        call(owner, repo, pull_number=103, since=None),
+    ]
+    mock_api_client.get_review_comments.assert_has_calls(expected_review_comment_calls, any_order=True)
+    assert mock_api_client.get_review_comments.call_count == len(mock_pr_data_page1) + len(mock_pr_data_page2)
+
+    # Verify returned data
+    assert len(prs) == len(mock_pr_data_page1) + len(mock_pr_data_page2)
+    assert prs[0]["id"] == 1
+    assert prs[2]["id"] == 3
+
+    total_expected_issue_comments = len(mock_issue_comments_pr101) + len(mock_issue_comments_pr102) + len(mock_issue_comments_pr103)
+    assert len(issue_comments) == total_expected_issue_comments
+    if total_expected_issue_comments > 0:
+        assert issue_comments[0]["id"] == 10 # from pr101
+
+    total_expected_review_comments = len(mock_review_comments_pr101) + len(mock_review_comments_pr102) + len(mock_review_comments_pr103)
+    assert len(review_comments) == total_expected_review_comments
+    if total_expected_review_comments > 0:
+         # Order depends on PR processing order, check for specific items
+        assert any(c["id"] == 20 for c in review_comments) # from pr102
+        assert any(c["id"] == 21 for c in review_comments) # from pr103
+
+
+def test_fetch_all_data_for_repo_with_since_parameter(mock_api_client: MagicMock):
+    """Test fetch_all_data_for_repo when 'since' parameter is used."""
+    repo_full_name = "test_owner/test_repo"
+    last_fetch_time = "2023-01-15T10:00:00Z"
+    fetcher = GitHubFetcher(client=mock_api_client)
+
+    # Ensure get_last_fetched_at returns the specific timestamp
+    fetcher.get_last_fetched_at = MagicMock(return_value=last_fetch_time)
+
+    # Modify client to return fewer PRs if 'since' is used (optional, for more realistic mock)
+    # For this test, we'll assume the client still returns all PRs,
+    # and we're just checking the 'since' propagation.
+    # mock_api_client.get_pull_requests.return_value = [mock_pr_data_page2[0]] # Only PR 103
+    # def get_issue_comments_side_effect_since(owner, repo, issue_number, since):
+    #     assert since == last_fetch_time
+    #     if issue_number == 103: return mock_issue_comments_pr103
+    #     return []
+    # mock_api_client.get_issue_comments.side_effect = get_issue_comments_side_effect_since
+    # def get_review_comments_side_effect_since(owner, repo, pull_number, since):
+    #     assert since == last_fetch_time
+    #     if pull_number == 103: return mock_review_comments_pr103
+    #     return []
+    # mock_api_client.get_review_comments.side_effect = get_review_comments_side_effect_since
+
+
+    prs, issue_comments, review_comments = fetcher.fetch_all_data_for_repo(repo_full_name)
+
+    fetcher.get_last_fetched_at.assert_called_once_with(repo_full_name)
+
+    owner, repo = repo_full_name.split('/')
+    mock_api_client.get_pull_requests.assert_called_once_with(owner, repo, since=last_fetch_time)
+
+    # Check 'since' in calls to comment fetching methods
+    # The number of calls depends on the PRs returned by get_pull_requests
+    # which is currently all PRs (101, 102, 103)
+    expected_issue_comment_calls = [
+        call(owner, repo, issue_number=101, since=last_fetch_time),
+        call(owner, repo, issue_number=102, since=last_fetch_time),
+        call(owner, repo, issue_number=103, since=last_fetch_time),
+    ]
+    mock_api_client.get_issue_comments.assert_has_calls(expected_issue_comment_calls, any_order=True)
+    assert mock_api_client.get_issue_comments.call_count == len(mock_pr_data_page1) + len(mock_pr_data_page2)
+
+
+    expected_review_comment_calls = [
+        call(owner, repo, pull_number=101, since=last_fetch_time),
+        call(owner, repo, pull_number=102, since=last_fetch_time),
+        call(owner, repo, pull_number=103, since=last_fetch_time),
+    ]
+    mock_api_client.get_review_comments.assert_has_calls(expected_review_comment_calls, any_order=True)
+    assert mock_api_client.get_review_comments.call_count == len(mock_pr_data_page1) + len(mock_pr_data_page2)
+
+    # Data verification (should be the same as initial fetch if client doesn't filter by since)
+    assert len(prs) == len(mock_pr_data_page1) + len(mock_pr_data_page2)
+    total_expected_issue_comments = len(mock_issue_comments_pr101) + len(mock_issue_comments_pr102) + len(mock_issue_comments_pr103)
+    assert len(issue_comments) == total_expected_issue_comments
+    total_expected_review_comments = len(mock_review_comments_pr101) + len(mock_review_comments_pr102) + len(mock_review_comments_pr103)
+    assert len(review_comments) == total_expected_review_comments
+
+
+def test_fetch_all_data_for_repo_no_pull_requests(mock_api_client: MagicMock):
+    """Test fetch_all_data_for_repo when no pull requests are found."""
+    repo_full_name = "test_owner/empty_repo"
+    fetcher = GitHubFetcher(client=mock_api_client)
+    fetcher.get_last_fetched_at = MagicMock(return_value=None)
+
+    # Configure client to return no PRs
+    mock_api_client.get_pull_requests.return_value = []
+
+    prs, issue_comments, review_comments = fetcher.fetch_all_data_for_repo(repo_full_name)
+
+    owner, repo = repo_full_name.split('/')
+    mock_api_client.get_pull_requests.assert_called_once_with(owner, repo, since=None)
+
+    # No PRs, so no calls to fetch comments
+    mock_api_client.get_issue_comments.assert_not_called()
+    mock_api_client.get_review_comments.assert_not_called()
+
+    assert len(prs) == 0
+    assert len(issue_comments) == 0
+    assert len(review_comments) == 0
+
+def test_fetch_all_data_for_repo_pr_without_number(mock_api_client: MagicMock, caplog):
+    """Test fetch_all_data_for_repo when a PR is missing the 'number' field."""
+    repo_full_name = "test_owner/weird_repo"
+    fetcher = GitHubFetcher(client=mock_api_client)
+    fetcher.get_last_fetched_at = MagicMock(return_value=None)
+
+    # PR data, one PR is missing 'number'
+    pr_with_number = {"id": 1, "number": 101, "title": "Good PR"}
+    pr_without_number = {"id": 2, "title": "PR Missing Number"} # No 'number' field
+    mock_api_client.get_pull_requests.return_value = [pr_with_number, pr_without_number]
+
+    # Adjust side effects for comments if necessary (only PR 101 should be processed for comments)
+    def get_issue_comments_side_effect(owner: str, repo: str, issue_number: int, since: Optional[str] = None):
+        if issue_number == 101: return mock_issue_comments_pr101
+        return [] # Should not be called for the PR without number
+    mock_api_client.get_issue_comments.side_effect = get_issue_comments_side_effect
+
+    def get_review_comments_side_effect(owner: str, repo: str, pull_number: int, since: Optional[str] = None):
+        if pull_number == 101: return mock_review_comments_pr101
+        return [] # Should not be called for the PR without number
+    mock_api_client.get_review_comments.side_effect = get_review_comments_side_effect
+
+
+    prs, issue_comments, review_comments = fetcher.fetch_all_data_for_repo(repo_full_name)
+
+    owner, repo = repo_full_name.split('/')
+    mock_api_client.get_pull_requests.assert_called_once_with(owner, repo, since=None)
+
+    # Comments should only be fetched for the PR with a number
+    mock_api_client.get_issue_comments.assert_called_once_with(owner, repo, issue_number=101, since=None)
+    mock_api_client.get_review_comments.assert_called_once_with(owner, repo, pull_number=101, since=None)
+
+    assert len(prs) == 2 # Both PRs are returned by get_pull_requests
+    assert len(issue_comments) == len(mock_issue_comments_pr101)
+    assert len(review_comments) == len(mock_review_comments_pr101)
+
+    # Check for warning log
+    assert "PRデータに 'number' が含まれていません: 2" in caplog.text
+    assert caplog.records[0].levelname == "WARNING" # Assuming it's the first relevant log


### PR DESCRIPTION
Implemented the GitHubFetcher class in `src/github_api/fetcher.py`
to handle higher-level data fetching logic using the GitHubAPIClient.
This includes fetching pull requests, issue comments, and review comments
for a given repository, with consideration for a 'since' timestamp.

Added comprehensive unit tests for GitHubFetcher in
`tests/unit/github_api/test_fetcher.py`. These tests cover:
- Initialization of the fetcher.
- Mocked behavior of `get_last_fetched_at`.
- Fetching all data for a repository, including:
  - Initial fetch (no 'since' parameter).
  - Fetching with a 'since' parameter.
  - Handling cases with no pull requests.
  - Handling pull requests that might be missing a 'number' field.

Ensured all tests pass by resolving import issues, installing
dependencies, and correcting mock patch usage.